### PR TITLE
fix: correct allowed-tools Bash pattern syntax in skill commands

### DIFF
--- a/commands/blueprint-abandon.md
+++ b/commands/blueprint-abandon.md
@@ -1,7 +1,7 @@
 ---
 name: blueprint-abandon
 description: 廢棄進行中的藍圖
-allowed-tools: Read, Bash(source *), Bash(mkdir *), Bash(mv *), Bash(ls *), Bash(date *)
+allowed-tools: Read, Bash(source:*), Bash(mkdir:*), Bash(mv:*), Bash(ls:*), Bash(date:*)
 ---
 
 # Blueprint Abandon - 廢棄藍圖

--- a/commands/blueprint-ready.md
+++ b/commands/blueprint-ready.md
@@ -1,7 +1,7 @@
 ---
 name: blueprint-ready
 description: 檢查藍圖狀態，建議下一步
-allowed-tools: Read, Edit, Bash(git rev-parse *), Bash(git branch *), Bash(git checkout *), Bash(bd create *), Bash(bd list *), Bash(bd update *)
+allowed-tools: Read, Edit, Bash(git:rev-parse *), Bash(git:branch *), Bash(git:checkout *), Bash(bd:create *), Bash(bd:list *), Bash(bd:update *)
 ---
 
 # Blueprint Ready - 檢查狀態

--- a/commands/blueprint-resume.md
+++ b/commands/blueprint-resume.md
@@ -1,7 +1,7 @@
 ---
 name: blueprint-resume
 description: 恢復暫停的藍圖
-allowed-tools: Read, Bash(source *), Bash(mkdir *), Bash(mv *), Bash(ls *), Bash(date *)
+allowed-tools: Read, Bash(source:*), Bash(mkdir:*), Bash(mv:*), Bash(ls:*), Bash(date:*)
 ---
 
 # Blueprint Resume - 恢復藍圖

--- a/commands/blueprint-suspend.md
+++ b/commands/blueprint-suspend.md
@@ -1,7 +1,7 @@
 ---
 name: blueprint-suspend
 description: 暫停藍圖
-allowed-tools: Read, Bash(source *), Bash(mkdir *), Bash(mv *), Bash(ls *), Bash(date *)
+allowed-tools: Read, Bash(source:*), Bash(mkdir:*), Bash(mv:*), Bash(ls:*), Bash(date:*)
 ---
 
 # Blueprint Suspend - 暫停藍圖


### PR DESCRIPTION
## What
Fixed the `allowed-tools` Bash pattern syntax in 4 skill command files.

The Bash tool filter requires a colon as the delimiter between the command and its arguments (e.g. `Bash(git:rev-parse *)`), but the entries were using a space (e.g. `Bash(git rev-parse *)`), which caused Claude Code to not recognize the permissions — resulting in repeated permission prompts during skill execution.

**Files changed:**
- `commands/blueprint-abandon.md` — `source`, `mkdir`, `mv`, `ls`, `date`
- `commands/blueprint-ready.md` — `git rev-parse`, `git branch`, `git checkout`, `bd create`, `bd list`, `bd update`
- `commands/blueprint-resume.md` — `source`, `mkdir`, `mv`, `ls`, `date`
- `commands/blueprint-suspend.md` — `source`, `mkdir`, `mv`, `ls`, `date`

## Why
Space-separated syntax silently fails — Claude Code does not auto-allow the tool, resulting in repeated permission prompts that interrupt skill operations.

## 類型
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] survey
- [ ] docs

## Issues
Related #11

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)